### PR TITLE
fix: lint command now lints all files as expected

### DIFF
--- a/src/bin/scripts/lint.js
+++ b/src/bin/scripts/lint.js
@@ -18,7 +18,7 @@ const lintArgs =
 		? // Files are passed in, use args as provided
 		  args
 		: // Supplement args with all files
-		  [...args, "--", "./"]
+		  [...args, "--ext", ".js,.jsx,.ts,.tsx", "--", "./"]
 
 spawn(
 	{


### PR DESCRIPTION
Previously, the lint command was only linting files in the root directory.